### PR TITLE
Workaround for homebrew error

### DIFF
--- a/installOSXgen
+++ b/installOSXgen
@@ -1,18 +1,38 @@
 
-echo "Installing brew"
+setup_brew() {
+    echo "Installing brew"
 
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew update
-brew upgrade
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    brew update
+    brew upgrade
 
-echo "Installing Git/Python/Cmake"
+    echo ""
+    echo "Installed HOMEBREW, check for post-intallation messsages"
+    echo "If everything is good, installing should start automagically"
+}
 
-brew install git
-brew install python3
-python3 -m ensurepip
-python3 -m ensurepip --upgrade
-python3 -m pip install matplotlib
-python3 -m pip install numpy
-python3 -m pip install scipy
-python3 -m pip install iminuit
-brew install cmake
+setup_workspace() {
+    echo ""
+    echo "Installing Git/Python/Cmake"
+
+    which -s brew
+    if [[ $? != 0 ]] ; then
+	echo "Please install homebrew or check the postinstall messages "
+	echo "saying to source the executible, then proceed to the second "
+	echo "part of the installation by inserting the command "
+	echo "'setup_workspace'"
+    else 
+	brew install git
+	brew install python3
+	python3 -m ensurepip
+	python3 -m ensurepip --upgrade
+	python3 -m pip install matplotlib
+	python3 -m pip install numpy
+	python3 -m pip install scipy
+	python3 -m pip install iminuit
+	brew install cmake
+    fi
+}
+    
+setup_brew
+setup_workspace

--- a/installOSXroot
+++ b/installOSXroot
@@ -1,14 +1,28 @@
 
-echo "Installing ROOT"
+which -s brew
 
-cd
-mkdir Software
-cd Software
-mkdir root_build root_install
-git clone --branch latest-stable https://github.com/root-project/root.git root_src
-cd root_build
-cmake -DCMAKE_INSTALL_PREFIX=../root_install -Dbuiltin_glew=ON ../root_src
+if [[ $? != 0 ]] ; then
 
-echo "Compiling ROOT. It will take a while..."
+    echo "'homebrew' is apparently not installed or not setup correctly, "
+    echo "check again with the installation output for possible post-"
+    echo "install suggested commands, then run again 'setup_workspace' "
+    echo "and then run again 'source CalcoloXFisica/installOSXroot' to "
+    echo "install root correctly"
 
-cmake --build . -- install -j4
+else
+
+    echo "Installing ROOT"
+
+    cd
+    mkdir Software
+    cd Software
+    mkdir root_build root_install
+    git clone --branch latest-stable https://github.com/root-project/root.git root_src
+    cd root_build
+    cmake -DCMAKE_INSTALL_PREFIX=../root_install -Dbuiltin_glew=ON ../root_src
+
+    echo "Compiling ROOT. It will take a while..."
+
+    cmake --build . -- install -j4
+fi
+

--- a/installWSL
+++ b/installWSL
@@ -63,4 +63,4 @@ then
 fi
 echo "cd" >> ~/.profile
 
-
+cd


### PR DESCRIPTION
Ho provato ad implementare un possibile workaround per aiutare gli studenti a installare correttamente `homebrew` e poi i relativi pacchetti che sono richiesti, impedendo a software successivi di installarsi se non è presente il comando `brew` e suggerendo cosa fare nel caso di questo errore.

